### PR TITLE
README update + anchor test command fix

### DIFF
--- a/Anchor.toml
+++ b/Anchor.toml
@@ -18,4 +18,4 @@ wallet = "~/.config/solana/id.json"
 upgradeable = true
 
 [scripts]
-test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 tests/**/*.spec.ts"
+test = "yarn run ts-mocha -p ./tsconfig.json -t 1000000 packages/tests/**/*.spec.ts"

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To execute the test suites, run:
 anchor test
 ```
 
-Test scenarios are located in the `tests/*.spec.ts` files
+Test scenarios are located in the `packages/tests/*.spec.ts` files
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ To run localnet:
 yarn localnet
 ```
 
+### Deploy
+
+To use the program, regenerate its ID, rebuild, and deploy:
+
+```bash
+rm -rf target
+anchor keys sync
+anchor build
+anchor deploy --provider.cluster <localnet, devnet, testnet or mainnet-beta>
+```
+
 ### Initialize
 
 ```bash


### PR DESCRIPTION
1. fix the `anchor test` command and it's related README section
2. Add program deployment instructions required to run all other steps described in the CLI section of the

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the test configuration to reflect a reorganized directory structure.
- **Documentation**
	- Revised test instructions to reference updated paths.
	- Introduced a new “Deploy” section outlining steps to regenerate, rebuild, and deploy the program.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->