### PR TITLE
Introduced Merkle Tree (Root + Proofs) generation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ To run localnet:
 yarn localnet
 ```
 
+
+## Admin Actions
+
 ### Initialize
 
 ```bash
@@ -129,6 +132,8 @@ yarn cli admin shutdown \
   --token-mint '9567hvuTyD6YCm5y3g8P1xCgfg8vh12nETfcfkWWANsy'
 ```
 
+## User Actions
+
 ### Claim
 
 ```bash
@@ -156,4 +161,42 @@ yarn cli read claimed-rewards \
   --private-key-file <filename> \
   --cluster <localnet, devnet, testnet or mainnet-beta> \
   --claimant <claimant_address>
+```
+
+## Generate Merkle Tree (Root + Proofs)
+
+### Generate a test (address, balance) dataset
+
+The test generated dataset can be used as a template to create a real one.
+
+```bash
+yarn cli merkle-tree generate-dataset \
+  --size <dataset size, number> \
+  --output-dataset-file <path to CSV data file to write dataset to>
+```
+
+Example:
+
+```bash
+yarn cli merkle-tree generate-dataset \
+  --size 33 \
+  --output-dataset-file example_data/dataset_example.csv
+```
+
+### Generate Merkle root and proofs
+
+```bash
+yarn cli merkle-tree generate-merkle-tree \
+  --input-dataset-file <input CSV file path containing an airdrop dataset> \
+  --output-merkle-root-file <output JSON file path to write Merkle root to> \
+  --output-merkle-proof-folder <output folder to write Merkle proof JSON file to>
+```
+
+Example:
+
+```bash
+yarn cli merkle-tree generate-merkle-tree \
+  --input-dataset-file example_data/dataset_example.csv \
+  --output-merkle-root-file example_data/merkle_root-example.json \
+  --output-merkle-proof-folder example_data/merkle_proofs_example
 ```

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,6 +11,8 @@
         "@solana/spl-token": "^0.4.9",
         "@solana/web3.js": "^1.95.4",
         "@marinade.finance/spl-governance": "^0.3.25",
+        "bs58": "^6.0.0",
+        "merkletreejs": "^0.5.1",
         "yargs": "^17.7.2"
     },
     "devDependencies": {

--- a/packages/cli/src/commands/merkle-tree/generateDataset.ts
+++ b/packages/cli/src/commands/merkle-tree/generateDataset.ts
@@ -1,0 +1,59 @@
+import { CommandModule } from 'yargs';
+import fs from 'node:fs';
+
+const sizeArg = 'size';
+const outputDatasetFileArg = 'output-dataset-file';
+
+export const generateDatasetCommand: CommandModule = {
+    command: 'generate-dataset',
+    describe: 'Generate a CSV list of addresses and their corresponding airdrop balances',
+
+    builder: (builder) => {
+        return builder
+            .option(sizeArg, {
+                demandOption: true,
+                type: 'number',
+                description: 'Dataset size; number of records to generate',
+            })
+            .option(outputDatasetFileArg, {
+                demandOption: true,
+                type: 'string',
+                description: 'Path to an output dataset CSV file to write the generated list to',
+            });
+    },
+    handler: async (args): Promise<void> => {
+        const size = args[sizeArg] as number;
+        const outputDatasetFilePath = args[outputDatasetFileArg] as string;
+
+        const csvContent = generateSolanaAddressBalancesCSV(size);
+        fs.writeFileSync(outputDatasetFilePath, csvContent, 'utf8');
+        console.log(`Successfully wrote ${size} addresses and balances to CSV file ${outputDatasetFilePath}`);
+    },
+};
+
+function generateSolanaAddressBalancesCSV(n: number) {
+    let csvContent = "Solana Address,Lamports Balance\n";
+
+    for (let i = 0; i < n; i++) {
+        const address = generateSolanaAddress();
+        const balance = generateSafeBalance();
+        csvContent += `${address},${balance}\n`;
+    }
+
+    return csvContent;
+}
+
+function generateSolanaAddress() {
+    const characters = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+    let address = '';
+    for (let i = 0; i < 44; i++) {
+        address += characters.charAt(Math.floor(Math.random() * characters.length));
+    }
+    return address;
+}
+
+function generateSafeBalance() {
+    const min = 1000000000;  // Smallest 10-digit number
+    const max = 99999999999; // Largest 11-digit number
+    return Math.floor(Math.random() * (max - min + 1)) + min;
+}

--- a/packages/cli/src/commands/merkle-tree/generateDataset.ts
+++ b/packages/cli/src/commands/merkle-tree/generateDataset.ts
@@ -1,5 +1,8 @@
 import { CommandModule } from 'yargs';
+import { MerkleTree } from 'merkletreejs';
 import fs from 'node:fs';
+import path from 'path';
+import { Keypair } from "@solana/web3.js";
 
 const sizeArg = 'size';
 const outputDatasetFileArg = 'output-dataset-file';
@@ -26,7 +29,11 @@ export const generateDatasetCommand: CommandModule = {
         const outputDatasetFilePath = args[outputDatasetFileArg] as string;
 
         const csvContent = generateSolanaAddressBalancesCSV(size);
+
+        // Create output directory if it doesn't exist
+        fs.mkdirSync(path.dirname(outputDatasetFilePath), { recursive: true });
         fs.writeFileSync(outputDatasetFilePath, csvContent, 'utf8');
+
         console.log(`Successfully wrote ${size} addresses and balances to CSV file ${outputDatasetFilePath}`);
     },
 };
@@ -44,12 +51,7 @@ function generateSolanaAddressBalancesCSV(n: number) {
 }
 
 function generateSolanaAddress() {
-    const characters = '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
-    let address = '';
-    for (let i = 0; i < 44; i++) {
-        address += characters.charAt(Math.floor(Math.random() * characters.length));
-    }
-    return address;
+    return Keypair.generate().publicKey.toBase58();
 }
 
 function generateSafeBalance() {

--- a/packages/cli/src/commands/merkle-tree/generateMerkleTree.ts
+++ b/packages/cli/src/commands/merkle-tree/generateMerkleTree.ts
@@ -1,0 +1,110 @@
+import {CommandModule} from 'yargs';
+import { MerkleTree } from 'merkletreejs';
+import { createHash } from 'crypto';
+import bs58 from 'bs58';
+import fs from 'node:fs';
+import path from 'path';
+
+const inputDatasetFileArg = 'input-dataset-file';
+const outputMerkleRootFileArg = 'output-merkle-root-file';
+const outputMerkleProofFolderArg = 'output-merkle-proof-folder';
+
+export const generateMerkleTreeCommand: CommandModule = {
+    command: 'generate-merkle-tree',
+    describe: 'Generate a Merkle tree (root + proofs) for the list of addresses and their corresponding airdrop balances',
+
+    builder: (builder) => {
+        return builder
+            .option(inputDatasetFileArg, {
+                demandOption: true,
+                type: 'string',
+                description: 'Path to an input dataset CSV file to read the airdrop (Solana Address, Lamports Balance) list from',
+            })
+            .option(outputMerkleRootFileArg, {
+                demandOption: true,
+                type: 'string',
+                description: 'Path to an output Merkle root JSON file to write Merkle root for the dataset to'
+            })
+            .option(outputMerkleProofFolderArg, {
+                demandOption: true,
+                type: 'string',
+                description: 'Path to an output Merkle proof folder to write Merkle proof JSON files to',
+            });
+    },
+    handler: async (args): Promise<void> => {
+        const inputDatasetFilePath = args[inputDatasetFileArg] as string;
+        const outputMerkleRootFilePath = args[outputMerkleRootFileArg] as string;
+        const outputMerkleProofFolderPath = args[outputMerkleProofFolderArg] as string;
+
+        const dataset = readDatasetFile(inputDatasetFilePath);
+        const {merkleRoot, merkleProofs} = generateMerkleData(dataset);
+
+        // Save Merkle root
+        const merkleRootBytes = Array.from(merkleRoot);
+        fs.writeFileSync(outputMerkleRootFilePath, JSON.stringify(merkleRootBytes, null, 2));
+        console.log(`Merkle root saved to ${outputMerkleRootFilePath}`);
+
+        // Create output directory if it doesn't exist
+        fs.mkdirSync(outputMerkleProofFolderPath, { recursive: true });
+
+        // Save Merkle proofs
+        merkleProofs.forEach((proof, i) => {
+            const proofFilePath = path.join(outputMerkleProofFolderPath, `${dataset[i].SolanaAddress}.json`);
+            const jsonProof = proof.map(buffer => Array.from(buffer));
+            fs.writeFileSync(proofFilePath, JSON.stringify(jsonProof, null, 2));
+            console.log(`Merkle Proof for ${dataset[i].SolanaAddress} saved to ${proofFilePath}`);
+        });
+    },
+}
+
+interface DatasetRecord {
+    SolanaAddress: string;
+    LamportsBalance: string;
+}
+
+function hash(data: Buffer) {
+    return createHash('sha256').update(data).digest();
+}
+
+function hashLeaf(address: string, balance: string): Buffer {
+    const addressBuffer = bs58.decode(address);
+    const balanceBuffer = Buffer.from(BigInt(balance).toString(16).padStart(16, '0'), 'hex');
+    const combinedBuffer = Buffer.concat([addressBuffer, balanceBuffer]);
+    return hash(combinedBuffer);
+}
+
+function readDatasetFile(datasetFilePath: string): DatasetRecord[] {
+    const fileContent = fs.readFileSync(datasetFilePath, 'utf-8');
+    const lines = fileContent.trim().split('\n');
+    const header = lines[0].split(',');
+    const dataRows = lines.slice(1);
+
+    if (header.length !== 2 || header[0] !== 'Solana Address' || header[1] !== 'Lamports Balance') {
+        throw 'Invalid CSV header format.';
+    }
+
+    return dataRows.map(row => {
+        const [SolanaAddress, LamportsBalance] = row.split(',');
+        return {SolanaAddress: SolanaAddress.trim(), LamportsBalance: LamportsBalance.trim()};
+    });
+}
+
+function generateMerkleData(dataset: DatasetRecord[]): { merkleRoot: Buffer | null; merkleProofs: Buffer[][] } {
+    if (dataset.length === 0) {
+        return { merkleRoot: null, merkleProofs: [] };
+    }
+    const leaves = dataset.map(entry => hashLeaf(entry.SolanaAddress, entry.LamportsBalance));
+    const tree = new MerkleTree(leaves, (data: Buffer) => hash(data), {
+        hashLeaves: true, // default is false; directly affects Solana proof verification part
+        sortPairs: true, // default is false; directly affects Solana proof verification part
+        sortLeaves: true, // default is false; doesn't directly affect Solana proof verification part
+        duplicateOdd: false, // default is false; directly affects Solana proof verification part
+    });
+    const root = tree.getRoot();
+
+    const merkleProofs: Buffer[][] = leaves.map(leaf => { // Iterate over leaves directly
+        return tree.getProof(hash(leaf)).map(element => element.data); // Directly use element.data
+    });
+
+    return { merkleRoot: root, merkleProofs };
+}

--- a/packages/cli/src/commands/merkle-tree/index.ts
+++ b/packages/cli/src/commands/merkle-tree/index.ts
@@ -1,0 +1,10 @@
+import yargs from 'yargs';
+import { generateDatasetCommand } from './generateDataset';
+import {generateMerkleTreeCommand} from "./generateMerkleTree";
+
+export function merkleTreeCommandsBuilder(builder: yargs.Argv) {
+    return builder
+        .command(generateDatasetCommand)
+        .command(generateMerkleTreeCommand)
+        .demand(3, 'must provide a valid command');
+}

--- a/packages/cli/src/commands/merkle-tree/index.ts
+++ b/packages/cli/src/commands/merkle-tree/index.ts
@@ -6,5 +6,6 @@ export function merkleTreeCommandsBuilder(builder: yargs.Argv) {
     return builder
         .command(generateDatasetCommand)
         .command(generateMerkleTreeCommand)
+        // demand "3" explicitly requires the command to contain a sub-command defined above
         .demand(3, 'must provide a valid command');
 }

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -5,6 +5,7 @@ import { userCommandsBuilder } from './commands/user';
 import { CliContext, TransactionMode } from './context';
 import { readKeypairFromFile } from './utils';
 import { readCommandsBuilder } from './commands/read-only';
+import { merkleTreeCommandsBuilder } from './commands/merkle-tree';
 
 const modeArg = 'mode';
 const privateKeyFileArg = 'private-key-file';
@@ -19,6 +20,7 @@ async function main(): Promise<void> {
         .command('admin', 'Admin actions', adminCommandsBuilder)
         .command('user', 'User actions', userCommandsBuilder)
         .command('read', 'Read actions', readCommandsBuilder)
+        .command('merkle-tree', 'Merkle tree actions', merkleTreeCommandsBuilder)
         // common args
         .option(modeArg, {
             type: 'string',

--- a/yarn.lock
+++ b/yarn.lock
@@ -605,6 +605,11 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
+base-x@^5.0.0:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
+  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
+
 base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -692,6 +697,13 @@ bs58@^4.0.0, bs58@^4.0.1:
   dependencies:
     base-x "^3.0.2"
 
+bs58@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
+  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
+  dependencies:
+    base-x "^5.0.0"
+
 buffer-from@^1.0.0, buffer-from@^1.1.0:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.2.tgz#2b146a6fd72e80b4f55d255f35ed59a3a9a41bd5"
@@ -701,6 +713,11 @@ buffer-layout@^1.2.0, buffer-layout@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/buffer-layout/-/buffer-layout-1.2.2.tgz#b9814e7c7235783085f9ca4966a0cfff112259d5"
   integrity sha512-kWSuLN694+KTk8SrYvCqwP2WcgQjoRCiF5b4QDvkkz8EmgD+aWAIceGFKMIAdmF/pH+vpgNV3d3kAKorcdAmWA==
+
+buffer-reverse@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/buffer-reverse/-/buffer-reverse-1.0.1.tgz#49283c8efa6f901bc01fa3304d06027971ae2f60"
+  integrity sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg==
 
 buffer@6.0.3, buffer@^6.0.3, buffer@~6.0.3:
   version "6.0.3"
@@ -870,6 +887,11 @@ crypto-hash@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/crypto-hash/-/crypto-hash-1.3.0.tgz#b402cb08f4529e9f4f09346c3e275942f845e247"
   integrity sha512-lyAZ0EMyjDkVvz8WOeVnuCPvKVBXcMv1l5SVqO1yC7PzTwrD/pPje/BIRbWhMoPe436U+Y2nD7f5bFx0kt+Sbg==
+
+crypto-js@^4.2.0:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.2.0.tgz#4d931639ecdfd12ff80e8186dba6af2c2e856631"
+  integrity sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==
 
 debug@4.3.3:
   version "4.3.3"
@@ -1603,6 +1625,15 @@ math-intrinsics@^1.1.0:
   resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
   integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
 
+merkletreejs@^0.5.1:
+  version "0.5.1"
+  resolved "https://registry.yarnpkg.com/merkletreejs/-/merkletreejs-0.5.1.tgz#cbb30f5db453b437510c0d32f91ec969a63c8e83"
+  integrity sha512-iR1MI07/HvioeZUvG9EQorcY6zSun8LCmW4jqNbHdecv2XsOt7qYMHWspcjY//lwaSM8/GUMX7ehpm/+UvqrqQ==
+  dependencies:
+    buffer-reverse "^1.0.1"
+    crypto-js "^4.2.0"
+    treeify "^1.1.0"
+
 mime-db@1.52.0:
   version "1.52.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
@@ -2046,6 +2077,11 @@ tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
+
+treeify@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/treeify/-/treeify-1.1.0.tgz#4e31c6a463accd0943879f30667c4fdaff411bb8"
+  integrity sha512-1m4RA7xVAJrSGrrXGs0L3YTwyvBs2S8PbRHaLZAkFw7JR8oIFwYtysxlBZhYIa7xSyiYJKZ3iGrrk55cGA3i9A==
 
 ts-mocha@^10.0.0:
   version "10.0.0"


### PR DESCRIPTION
Introduced a new category of the commands 'merkle-tree' to generate Merkle trees for the (account,balance) Airdrop datasets:

generate-dataset command: generates a test CSV list of addresses and their corresponding airdrop balances
generate-merkle-tree command: generates a Merkle tree (root + proofs) for the list of addresses and their corresponding airdrop balances

Commands manually tested to work with the rest of existing commands; update Merkle root + claim flow was tested for the datasets of size: 1, 2 (sorted), 2 (non-sorted), 3 (odd), 3 (even), 1233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Expanded user documentation with detailed instructions for administrative actions, user actions, and generating Merkle tree data.

- **New Features**
  - Introduced a CLI command to generate datasets with addresses and their airdrop balances.
  - Added a CLI command to create Merkle tree information, including a Merkle root and proofs.
  - Enhanced the CLI tool with integrated Merkle tree operations for smoother user interactions.
  - Added new dependencies to support Merkle tree functionalities.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->